### PR TITLE
Fix exception referencing delta input when no newline insert is given

### DIFF
--- a/src/InlineListener.php
+++ b/src/InlineListener.php
@@ -53,7 +53,7 @@ abstract class InlineListener extends Listener
             });
 
             if (!$next) {
-                throw new Exception("Unable to find a next element. Invalid DELTA on '{$this->input}'");
+                throw new Exception("Unable to find a next element. Invalid DELTA on '{$pick->line->input}'");
             }
             $next->addPrepend($pick->line->input);
         }


### PR DESCRIPTION
This exception is thrown when the last operation is an insert with attributes.

E.g.:

```php
$contents = [
	'ops' => [
		['insert' => 'first '],
		['insert' => 'second', 'attributes' => ['bold' => true]],
	],
];

$lexer     = new \nadar\quill\Lexer($contents);
$rendered  = $lexer->render();
$reference = '<p>first <strong>second</strong></p>';

var_dump($rendered === $reference);
var_dump($rendered);
var_dump($reference);
```

However, the data for the exception message is non existing.