### PR TITLE
Fix rendering lists with block level element in between

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.4
++ [#13](https://github.com/nadar/quill-delta-parser/pull/13) Fixed bug when lists are interrupted with block level elements (e.g. videos)
+
 ## 1.3.2 (3. July 2019)
 + [#15](https://github.com/nadar/quill-delta-parser/pull/15) Fixed bug when header contains (partial) formatting and line before header contains formatting
 

--- a/src/BlockListener.php
+++ b/src/BlockListener.php
@@ -38,7 +38,7 @@ abstract class BlockListener extends Listener
                 // its the same line as the start.. skip this one as its by default included in while operations
                 if ($line === $pick->line) {
                     return true;
-                } elseif (($line->hasEndNewline() || $line->hasNewline() || $line->isJsonInsert())) {
+                } elseif (($line->hasEndNewline() || $line->hasNewline() || ($line->isJsonInsert() && !$line->isInline()))) {
                     return false;
                 }
 

--- a/src/Line.php
+++ b/src/Line.php
@@ -435,7 +435,7 @@ class Line
      *
      * @return boolean
      */
-    public function isInline()
+    public function isInline(): bool
     {
         return $this->isInline;
     }

--- a/src/listener/Lists.php
+++ b/src/listener/Lists.php
@@ -79,7 +79,7 @@ class Lists extends BlockListener
                 if ($line->getAttribute(self::ATTRIBUTE_LIST)) {
                     return false;
                 }
-                // if one of those new lines contains a endnew line or newline store this information
+                // if one of those new lines contains a endnew line or newline or is block level store this information
                 if ($line->hasEndNewline() || $line->hasNewline() || $line->isJsonInsert()) {
                     $hasNextInside = true;
                 }

--- a/src/listener/Lists.php
+++ b/src/listener/Lists.php
@@ -49,7 +49,7 @@ class Lists extends BlockListener
                 // its the same line as the start.. skip this one as its by default included in while operations
                 if ($line == $pick->line) {
                     return true;
-                } elseif (($line->hasEndNewline() || $line->hasNewline())) {
+                } elseif (($line->hasEndNewline() || $line->hasNewline() || $line->isJsonInsert())) {
                     return false;
                 }
 
@@ -80,7 +80,7 @@ class Lists extends BlockListener
                     return false;
                 }
                 // if one of those new lines contains a endnew line or newline store this information
-                if ($line->hasEndNewline() || $line->hasNewline()) {
+                if ($line->hasEndNewline() || $line->hasNewline() || $line->isJsonInsert()) {
                     $hasNextInside = true;
                 }
             });

--- a/src/listener/Lists.php
+++ b/src/listener/Lists.php
@@ -66,7 +66,7 @@ class Lists extends BlockListener
                     return false;
                 }
                 // if one of those new lines contains a endnew line or newline or is block level store this information
-                if ($line->hasEndNewline() || $line->hasNewline() || $line->isJsonInsert()) {
+                if ($line->hasEndNewline() || $line->hasNewline() || ($line->isJsonInsert() && !$line->isInline())) {
                     $hasNextInside = true;
                 }
             });

--- a/tests/ListBlockTest.php
+++ b/tests/ListBlockTest.php
@@ -51,31 +51,39 @@ JSON;
 
     public $html = <<<'EOT'
 <p>Before</p>
+
 <ul>
 <li>A 1</li>
 <li><strong>A 2</strong></li>
 <li>A 3</li>
 </ul>
+
 <div class="embed-responsive embed-responsive-16by9">
 <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/Ybq878PMe_U?showinfo=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
+
 <ul>
 <li>B 1</li>
 <li>B <img src="https://example.com/image.jpg" alt="" class="img-responsive img-fluid" /> 2</li>
 <li>B 3</li>
 </ul>
+
 <p>In between</p>
+
 <ul>
 <li>C 1</li>
 <li>C 2</li>
 <li>C 3</li>
 </ul>
+
 <p><img src="https://example.com/image.jpg" alt="" class="img-responsive img-fluid" /></p>
+
 <ul>
 <li>D 1</li>
 <li>D 2</li>
 <li>D 3</li>
 </ul>
+
 <p>After</p>
 EOT;
 }

--- a/tests/ListBlockTest.php
+++ b/tests/ListBlockTest.php
@@ -6,144 +6,46 @@ class ListBlockTest extends DeltaTestCase
 {
     public $json = <<<'JSON'
 [
-    {
-      "insert": "Before\nA 1"
-    },
-    {
-      "attributes": {
-        "list": "bullet"
-      },
-      "insert": "\n"
-    },
-    {
-      "attributes": {
-        "bold": true
-      },
-      "insert": "A 2"
-    },
-    {
-      "attributes": {
-        "list": "bullet"
-      },
-      "insert": "\n"
-    },
-    {
-      "insert": "A 3"
-    },
-    {
-      "attributes": {
-        "list": "bullet"
-      },
-      "insert": "\n"
-    },
-    {
-      "insert": {
-        "video": "https://www.youtube.com/embed/Ybq878PMe_U?showinfo=0"
-      }
-    },
-    {
-      "insert": "B 1"
-    },
-    {
-      "attributes": {
-        "list": "bullet"
-      },
-      "insert": "\n"
-    },
-    {
-      "insert": "B "
-    },
-    {
-      "insert": {
-        "image": "https://example.com/image.jpg"
-      }
-    },
-    {
-      "insert": " 2"
-    },
-    {
-      "attributes": {
-        "list": "bullet"
-      },
-      "insert": "\n"
-    },
-    {
-      "insert": "B 3"
-    },
-    {
-      "attributes": {
-        "list": "bullet"
-      },
-      "insert": "\n"
-    },
-    {
-      "insert": "In between\n"
-    },
-    {
-      "insert": "C 1"
-    },
-    {
-      "attributes": {
-        "list": "bullet"
-      },
-      "insert": "\n"
-    },
-    {
-      "insert": "C 2"
-    },
-    {
-      "attributes": {
-        "list": "bullet"
-      },
-      "insert": "\n"
-    },
-    {
-      "insert": "C 3"
-    },
-    {
-      "attributes": {
-        "list": "bullet"
-      },
-      "insert": "\n"
-    },
-    {
-      "insert": {
-        "image": "https://example.com/image.jpg"
-      }
-    },
-    {
-      "insert": "\n"
-    },
-    {
-      "insert": "D 1"
-    },
-    {
-      "attributes": {
-        "list": "bullet"
-      },
-      "insert": "\n"
-    },
-    {
-      "insert": "D 2"
-    },
-    {
-      "attributes": {
-        "list": "bullet"
-      },
-      "insert": "\n"
-    },
-    {
-      "insert": "D 3"
-    },
-    {
-      "attributes": {
-        "list": "bullet"
-      },
-      "insert": "\n"
-    },
-    {
-      "insert": "After\n"
-    }
+    {"insert": "Before\n"},
+    
+    {"insert": "A 1"},
+    {"attributes": {"list": "bullet"}, "insert": "\n"},
+    {"insert": "A 2", "attributes": {"bold": true}},
+    {"attributes": {"list": "bullet"}, "insert": "\n"},
+    {"insert": "A 3"},
+    {"attributes": {"list": "bullet"}, "insert": "\n"},
+    
+    {"insert": {"video": "https://www.youtube.com/embed/Ybq878PMe_U?showinfo=0"}},
+    
+    {"insert": "B 1"},
+    {"attributes": {"list": "bullet"}, "insert": "\n"},
+    {"insert": "B "},
+    {"insert": {"image": "https://example.com/image.jpg"}},
+    {"insert": " 2"},
+    {"attributes": {"list": "bullet"}, "insert": "\n"},
+    {"insert": "B 3"},
+    {"attributes": {"list": "bullet"}, "insert": "\n"},
+    
+    {"insert": "In between\n"},
+    
+    {"insert": "C 1"},
+    {"attributes": {"list": "bullet"}, "insert": "\n"},
+    {"insert": "C 2"},
+    {"attributes": {"list": "bullet"}, "insert": "\n"},
+    {"insert": "C 3"},
+    {"attributes": {"list": "bullet"}, "insert": "\n"},
+    
+    {"insert": {"image": "https://example.com/image.jpg"}},
+    {"insert": "\n"},
+    
+    {"insert": "D 1"},
+    {"attributes": {"list": "bullet"}, "insert": "\n"},
+    {"insert": "D 2"},
+    {"attributes": {"list": "bullet"}, "insert": "\n"},
+    {"insert": "D 3"},
+    {"attributes": {"list": "bullet"}, "insert": "\n"},
+    
+    {"insert": "After\n"}
 ]
 JSON;
 

--- a/tests/ListBlockTest.php
+++ b/tests/ListBlockTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace nadar\quill\tests;
+
+class ListBlockTest extends DeltaTestCase
+{
+    public $json = <<<'JSON'
+[
+    {
+      "insert": "Before\nA 1"
+    },
+    {
+      "attributes": {
+        "list": "bullet"
+      },
+      "insert": "\n"
+    },
+    {
+      "attributes": {
+        "bold": true
+      },
+      "insert": "A 2"
+    },
+    {
+      "attributes": {
+        "list": "bullet"
+      },
+      "insert": "\n"
+    },
+    {
+      "insert": "A 3"
+    },
+    {
+      "attributes": {
+        "list": "bullet"
+      },
+      "insert": "\n"
+    },
+    {
+      "insert": {
+        "video": "https://www.youtube.com/embed/Ybq878PMe_U?showinfo=0"
+      }
+    },
+    {
+      "insert": "B 1"
+    },
+    {
+      "attributes": {
+        "list": "bullet"
+      },
+      "insert": "\n"
+    },
+    {
+      "insert": "B "
+    },
+    {
+      "insert": {
+        "image": "https://example.com/image.jpg"
+      }
+    },
+    {
+      "insert": " 2"
+    },
+    {
+      "attributes": {
+        "list": "bullet"
+      },
+      "insert": "\n"
+    },
+    {
+      "insert": "B 3"
+    },
+    {
+      "attributes": {
+        "list": "bullet"
+      },
+      "insert": "\n"
+    },
+    {
+      "insert": "In between\n"
+    },
+    {
+      "insert": "C 1"
+    },
+    {
+      "attributes": {
+        "list": "bullet"
+      },
+      "insert": "\n"
+    },
+    {
+      "insert": "C 2"
+    },
+    {
+      "attributes": {
+        "list": "bullet"
+      },
+      "insert": "\n"
+    },
+    {
+      "insert": "C 3"
+    },
+    {
+      "attributes": {
+        "list": "bullet"
+      },
+      "insert": "\n"
+    },
+    {
+      "insert": {
+        "image": "https://example.com/image.jpg"
+      }
+    },
+    {
+      "insert": "\n"
+    },
+    {
+      "insert": "D 1"
+    },
+    {
+      "attributes": {
+        "list": "bullet"
+      },
+      "insert": "\n"
+    },
+    {
+      "insert": "D 2"
+    },
+    {
+      "attributes": {
+        "list": "bullet"
+      },
+      "insert": "\n"
+    },
+    {
+      "insert": "D 3"
+    },
+    {
+      "attributes": {
+        "list": "bullet"
+      },
+      "insert": "\n"
+    },
+    {
+      "insert": "After\n"
+    }
+]
+JSON;
+
+    public $html = <<<'EOT'
+<p>Before</p>
+<ul>
+<li>A 1</li>
+<li><strong>A 2</strong></li>
+<li>A 3</li>
+</ul>
+<div class="embed-responsive embed-responsive-16by9">
+<iframe class="embed-responsive-item" src="https://www.youtube.com/embed/Ybq878PMe_U?showinfo=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+<ul>
+<li>B 1</li>
+<li>B <img src="https://example.com/image.jpg" alt="" class="img-responsive img-fluid" /> 2</li>
+<li>B 3</li>
+</ul>
+<p>In between</p>
+<ul>
+<li>C 1</li>
+<li>C 2</li>
+<li>C 3</li>
+</ul>
+<p><img src="https://example.com/image.jpg" alt="" class="img-responsive img-fluid" /></p>
+<ul>
+<li>D 1</li>
+<li>D 2</li>
+<li>D 3</li>
+</ul>
+<p>After</p>
+EOT;
+}


### PR DESCRIPTION
I found that block level elements (like video) inside a list don't break the list. They're also not contained in a list item. Thus the html ends up being:

```html
<ul>
  <li></li>
  <block></block>
  <li></li>
</ul>
```

This is not what I would expect. This PR seems to fix it, making the output:

```html
<ul>
  <li></li>
</ul>
<block></block>
<ul>
  <li></li>
</ul>
```

I still want to write some tests to confirm this. However, I'm also curious if you think this is indeed a bug and this PR is the right direction of fixing it.