### PR TITLE
Fix rendering header with inlineListeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.2 (3. July 2019)
++ Fixed bug when header contains (partial) formatting and line before header contains formatting
+
 ## 1.3.1 (6. June 2019)
 
 + [#12](https://github.com/nadar/quill-delta-parser/issues/12) Fixed bug when using quill parser on windows platforms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.3.2 (3. July 2019)
-+ Fixed bug when header contains (partial) formatting and line before header contains formatting
++ [#15](https://github.com/nadar/quill-delta-parser/pull/15) Fixed bug when header contains (partial) formatting and line before header contains formatting
 
 ## 1.3.1 (6. June 2019)
 

--- a/src/BlockListener.php
+++ b/src/BlockListener.php
@@ -21,11 +21,11 @@ abstract class BlockListener extends Listener
     }
 
     /**
-     * @param Line - An array with Line objects
+     * @param Pick $pick
      * @return Line
      * @since 1.3.2
      */
-    public function getFirstLine($pick)
+    protected function getFirstLine($pick)
     {
         $first = $pick->line;
 
@@ -33,7 +33,7 @@ abstract class BlockListener extends Listener
             function (&$index, Line $line) use ($pick, &$first) {
                 $index--;
                 // its the same line as the start.. skip this one as its by default included in while operations
-                if ($line == $pick->line) {
+                if ($line === $pick->line) {
                     return true;
                 } elseif (($line->hasEndNewline() || $line->hasNewline())) {
                     return false;

--- a/src/BlockListener.php
+++ b/src/BlockListener.php
@@ -21,11 +21,14 @@ abstract class BlockListener extends Listener
     }
 
     /**
+     * Returns the first Line from a Pick. If the Pick is the first Line, it will return it's own pick
+     * This is done because blockItems can consist of multiple inline items
+     *
      * @param Pick $pick
      * @return Line
      * @since 1.3.2
      */
-    protected function getFirstLine($pick)
+    protected function getFirstLine(Pick $pick) : Line
     {
         $first = $pick->line;
 

--- a/src/BlockListener.php
+++ b/src/BlockListener.php
@@ -19,4 +19,31 @@ abstract class BlockListener extends Listener
     {
         return self::TYPE_BLOCK;
     }
+
+    /**
+     * @param Line - An array with Line objects
+     * @return Line
+     * @since 1.3.2
+     */
+    public function getFirstLine($pick)
+    {
+        $first = $pick->line;
+
+        $pick->line->while(
+            function (&$index, Line $line) use ($pick, &$first) {
+                $index--;
+                // its the same line as the start.. skip this one as its by default included in while operations
+                if ($line == $pick->line) {
+                    return true;
+                } elseif (($line->hasEndNewline() || $line->hasNewline())) {
+                    return false;
+                }
+
+                // assign the line to $first
+                $first = $line;
+                return true;
+            }
+        );
+        return $first;
+    }
 }

--- a/src/listener/Heading.php
+++ b/src/listener/Heading.php
@@ -45,24 +45,10 @@ class Heading extends BlockListener
                 // prevent html injection in case the attribute is user input
                 throw new Exception('An unknown heading level "'.$pick->heading.'" has been detected.');
             }
-
-            $first = $pick->line;
 	
-            $pick->line->while(function (&$index, Line $line) use ($pick, &$first) {
-                $index--;
-                // its the same line as the start.. skip this one as its by default included in while operations
-	            if ($line == $pick->line) {
-                    return true;
-                } elseif (($line->hasEndNewline() || $line->hasNewline())) {
-                    return false;
-				}
-
-                // assign the line to $first
-				$first = $line;
-				return true;
-			});
+	        $first = $this->getFirstLine($pick);
 	
-            // while from first to the pick line and store content in buffer
+	        // while from first to the pick line and store content in buffer
             $buffer = null;
             $first->while(function (&$index, Line $line) use (&$buffer, $pick) {
 				$index++;
@@ -77,4 +63,26 @@ class Heading extends BlockListener
 			$pick->line->setDone();
 		}
     }
+
+	private function getFirstLine($pick) {
+		$first = $pick->line;
+		
+		$pick->line->while(
+			function (&$index, Line $line) use ($pick, &$first) {
+				$index--;
+				// its the same line as the start.. skip this one as its by default included in while operations
+				if ($line == $pick->line) {
+					return true;
+				}
+				elseif (($line->hasEndNewline() || $line->hasNewline())) {
+					return false;
+				}
+				
+				// assign the line to $first
+				$first = $line;
+				return true;
+			}
+		);
+		return $first;
+	}
 }

--- a/src/listener/Heading.php
+++ b/src/listener/Heading.php
@@ -43,25 +43,25 @@ class Heading extends BlockListener
         foreach ($this->picks() as $pick) {
             if (!in_array($pick->heading, $this->levels)) {
                 // prevent html injection in case the attribute is user input
-                throw new Exception('An unknown heading level "'.$pick->heading.'" has been detected.');
+                throw new Exception('An unknown heading level "' . $pick->heading . '" has been detected.');
             }
-	
-	        $first = $this->getFirstLine($pick);
-	
-	        // while from first to the pick line and store content in buffer
+
+            $first = $this->getFirstLine($pick);
+
+            // while from first to the pick line and store content in buffer
             $buffer = null;
             $first->while(function (&$index, Line $line) use (&$buffer, $pick) {
-				$index++;
-				$buffer.= $line->getInput();
-				$line->setDone();
-				if ($index == $pick->line->getIndex()) {
-					return false;
-				}
-			});
-	
-			$pick->line->output = '<h'.$pick->heading.'>'.$buffer . '</h'.$pick->heading.'>';
-			$pick->line->setDone();
-		}
+                $index++;
+                $buffer .= $line->getInput();
+                $line->setDone();
+                if ($index == $pick->line->getIndex()) {
+                    return false;
+                }
+            });
+
+            $pick->line->output = '<h' . $pick->heading . '>' . $buffer . '</h' . $pick->heading . '>';
+            $pick->line->setDone();
+        }
     }
 
 	private function getFirstLine($pick) {

--- a/src/listener/Heading.php
+++ b/src/listener/Heading.php
@@ -63,26 +63,4 @@ class Heading extends BlockListener
             $pick->line->setDone();
         }
     }
-
-	private function getFirstLine($pick) {
-		$first = $pick->line;
-		
-		$pick->line->while(
-			function (&$index, Line $line) use ($pick, &$first) {
-				$index--;
-				// its the same line as the start.. skip this one as its by default included in while operations
-				if ($line == $pick->line) {
-					return true;
-				}
-				elseif (($line->hasEndNewline() || $line->hasNewline())) {
-					return false;
-				}
-				
-				// assign the line to $first
-				$first = $line;
-				return true;
-			}
-		);
-		return $first;
-	}
 }

--- a/src/listener/Lists.php
+++ b/src/listener/Lists.php
@@ -42,21 +42,7 @@ class Lists extends BlockListener
         $isOpen = false;
         $listTag = null;
         foreach ($this->picks() as $pick) {
-            $first = $pick->line;
-            // Go back to the first element which is not in the LIST of items and store the current item into $first
-            $pick->line->while(function (&$index, Line $line) use ($pick, &$first) {
-                $index--;
-                // its the same line as the start.. skip this one as its by default included in while operations
-                if ($line == $pick->line) {
-                    return true;
-                } elseif (($line->hasEndNewline() || $line->hasNewline())) {
-                    return false;
-                }
-
-                // assign the line to $first
-                $first = $line;
-                return true;
-            });
+            $first = $this->getFirstLine($pick);
 
             // while from first to the pick line and store content in buffer
             $buffer = null;

--- a/tests/BoldContentTest.php
+++ b/tests/BoldContentTest.php
@@ -4,18 +4,11 @@ namespace nadar\quill\tests;
 class BoldContentTest extends DeltaTestCase
 {
     public $json = <<<'JSON'
-{"ops": [
-  {"insert": "Heading 1","attributes": {"bold": true}},
-  {"insert": "\n","attributes": {"header": 1}},
-  {"insert": "list"},
-  {"insert": "\n","attributes": {"list": "bullet"}},
-  {"insert": "list"},{"attributes": {"list": "bullet"},"insert": "\n"},
-  {"insert": "Heading 2"},{"attributes": {"header": 2},"insert": "\n"}
-]}
+{"ops":[{"attributes":{"bold":true},"insert":"Formatted"},{"insert":"\n"},{"attributes":{"bold":true},"insert":"Heading 1"},{"attributes":{"header":1},"insert":"\n"},{"insert":"list"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"list"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"Heading 2"},{"attributes":{"header":2},"insert":"\n"}]}
 
 JSON;
 
     public $html = <<<'EOT'
-<h1><strong>Heading 1</strong></h1><ul><li>list</li><li>list</li></ul><h2>Heading 2</h2>
+<p><strong>Formatted</strong></p><h1><strong>Heading 1</strong></h1><ul><li>list</li><li>list</li></ul><h2>Heading 2</h2>
 EOT;
 }

--- a/tests/BoldContentTest.php
+++ b/tests/BoldContentTest.php
@@ -4,7 +4,15 @@ namespace nadar\quill\tests;
 class BoldContentTest extends DeltaTestCase
 {
     public $json = <<<'JSON'
-{"ops":[{"attributes":{"bold":true},"insert":"Formatted"},{"insert":"\n"},{"attributes":{"bold":true},"insert":"Heading 1"},{"attributes":{"header":1},"insert":"\n"},{"insert":"list"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"list"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"Heading 2"},{"attributes":{"header":2},"insert":"\n"}]}
+{"ops": [
+  {"insert": "Heading 1","attributes": {"bold": true}},
+  {"insert": "\n","attributes": {"header": 1}},
+  {"insert": "list"},
+  {"insert": "\n","attributes": {"list": "bullet"}},
+  {"insert": "list"},{"attributes": {"list": "bullet"},"insert": "\n"},
+  {"insert": "Heading 2"},{"attributes": {"header": 2},"insert": "\n"}
+]}
+
 JSON;
 
     public $html = <<<'EOT'

--- a/tests/HeadingContentTest.php
+++ b/tests/HeadingContentTest.php
@@ -1,0 +1,22 @@
+<?php
+namespace nadar\quill\tests;
+
+class HeadingContentTest extends DeltaTestCase
+{
+	public $json = <<<'JSON'
+{"ops":[
+  {"insert":"xyz","attributes":{"bold":true}},
+  {"insert":"\n"},
+  {"insert":"regular"},
+  {"insert":"bold","attributes":{"bold":true}},
+  {"insert":"italic", "attributes":{"italic":true}},
+  {"insert":"\n","attributes":{"header":1}},
+  {"insert":"xyz\n"}
+]}
+
+JSON;
+	
+	public $html = <<<'EOT'
+<p><strong>xyz</strong></p><h1>regular<strong>bold</strong><em>italic</em></h1><p>xyz</p>
+EOT;
+}


### PR DESCRIPTION
I found that headers behaved strange when they had partially italic or bold text.
Also, text before headers disappeared if they had an attribute applied to them - this was even put in a test. I think this is not desired behavior.

I changed the render to look further back, exactly like in lists, in order to render the headers as expected. 
