### PR TITLE
PHP8 - test for array key presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.6.1 (1. June 2021)
+
++ [#48](https://github.com/nadar/quill-delta-parser/pull/48) PHP 8 compatibility.
+
 ## 2.6.0 (2. December 2020)
 
 + [#42](https://github.com/nadar/quill-delta-parser/pull/42) Added PHP 8 Support.

--- a/src/Pick.php
+++ b/src/Pick.php
@@ -29,7 +29,7 @@ class Pick
      * @var Listener The listener object the picke was made from.
      */
     protected $listener;
-    
+
     /**
      * Create new line pick
      *
@@ -51,7 +51,7 @@ class Pick
      */
     public function __get($name)
     {
-        return $this->options[$name];
+        return array_key_exists($name, $this->options) ? $this->options[$name] : null;
     }
 
     /**


### PR DESCRIPTION
Hi there,


please review this pull request. Starting from PHP8, an E_WARNING is thrown when a value is retrieved from an array for a key that does not exist. The fix in this pull request should fix that issue.