### PR TITLE
option to override existing listeneres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.8.0 ()
+## 2.8.0 (8. March 2022)
 
-+ []() Provide new method to override existing listeneres with `overwriteListener()`.
++ [#56](https://github.com/nadar/quill-delta-parser/pull/56) Provide new method to override existing listeneres with `overwriteListener()`.
 
 ## 2.7.2 (27. October 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.8.0 ()
+
++ []() Provide new method to override existing listeneres with `overwriteListener()`.
+
 ## 2.7.2 (27. October 2021)
 
 + [#53](https://github.com/nadar/quill-delta-parser/pull/53) Lists listener, check for type being an array for compatibility with [Vanilla Forums](https://vanillaforums.com/).

--- a/README.md
+++ b/README.md
@@ -120,6 +120,27 @@ $lexer->registerListener($image);
 echo $lexer->render();
 ```
 
+If the class name has changed by our own image class, you can use `overwriteListener` to achieve the same result, but with your total custom class. The reason is that the listeners are registered by its class names.
+
+```php
+$mySuperClass = new class() extends Image {
+  // here is the custom class code ...
+}
+
+$lexer->overwriteListener(new Image, $mySuperClass);
+```
+
+Or of yourse if you have a seperate file for your class
+
+```php
+class MySuperDuperImageClass extends Image
+{
+    // here is the custom class code ...
+}
+
+$lexer->overwriteListener(new Image, new MySuperDuperImageClass);
+```
+
 ## Debuging
 
 Sometimes the handling of delta and how the data is parsed is very hard to debug and understand. Therefore you can use the debugger class which will print a table with informations about how the data is parsed.

--- a/composer.lock
+++ b/composer.lock
@@ -9,29 +9,30 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
             "autoload": {
@@ -58,7 +59,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
             },
             "funding": [
                 {
@@ -74,41 +75,42 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T18:47:58+00:00"
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
             },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -124,7 +126,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
             },
             "funding": [
                 {
@@ -132,7 +134,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T09:40:50+00:00"
+            "time": "2022-03-03T13:19:32+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -299,16 +301,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -319,7 +321,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -349,22 +352,22 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.5.1",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
+                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
-                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706",
                 "shasum": ""
             },
             "require": {
@@ -399,22 +402,22 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.1"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.0"
             },
-            "time": "2021-10-02T14:08:47+00:00"
+            "time": "2022-01-04T19:58:01+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.14.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
                 "shasum": ""
             },
             "require": {
@@ -466,9 +469,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
-            "time": "2021-09-10T09:02:12+00:00"
+            "time": "2021-12-08T12:19:24+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -539,16 +542,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "28af674ff175d0768a5a978e6de83f697d4a7f05"
+                "reference": "42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/28af674ff175d0768a5a978e6de83f697d4a7f05",
-                "reference": "28af674ff175d0768a5a978e6de83f697d4a7f05",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5",
+                "reference": "42c5ba5220e6904cbfe8b1a1bda7c0cfdc8c12f5",
                 "shasum": ""
             },
             "require": {
@@ -587,7 +590,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.5"
             },
             "funding": [
                 {
@@ -595,7 +598,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-19T06:46:01+00:00"
+            "time": "2021-12-02T12:42:26+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1109,16 +1112,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.3",
+            "version": "3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
+                "reference": "0c32ea2e40dbf59de29f3b49bf375176ce7dd8db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0c32ea2e40dbf59de29f3b49bf375176ce7dd8db",
+                "reference": "0c32ea2e40dbf59de29f3b49bf375176ce7dd8db",
                 "shasum": ""
             },
             "require": {
@@ -1127,7 +1130,7 @@
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -1174,7 +1177,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.4"
             },
             "funding": [
                 {
@@ -1182,7 +1185,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:47:53+00:00"
+            "time": "2021-11-11T13:51:24+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1515,20 +1518,23 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.23.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -1544,12 +1550,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1574,7 +1580,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1590,7 +1596,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2021-10-20T20:35:02+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -166,6 +166,28 @@ class Lexer
     }
 
     /**
+     * Overrite an existing listener with a new object
+     *
+     * An example could when you like to provide more options or access other elements which are not covered by the base class
+     * so you can extend from the built in listeneres and overrite them. This keeps also the hyrarchical level of the elements.
+     * 
+     * ```php
+     * $lexer->overwriteListener(new Image, new MyOwnImage);
+     * ```
+     * 
+     * As the `new Image` listener is already registered, it will just replace the object with `new MyOwnImage`.
+     * 
+     * @param Listener $listener The already registered listenere object
+     * @param Listener $new The new listener object
+     * @see https://github.com/nadar/quill-delta-parser/issues/55
+     * @since 2.8.0
+     */
+    public function overwriteListener(Listener $listener, Listener $new)
+    {
+        $this->listeners[$listener->type()][$listener->priority()][get_class($listener)] = $new;
+    }
+
+    /**
      * Get the input json as array.
      *
      * @return array The json as array formated.

--- a/tests/Issue55Test.php
+++ b/tests/Issue55Test.php
@@ -6,7 +6,7 @@ use nadar\quill\Lexer;
 use nadar\quill\Line;
 use nadar\quill\listener\Image;
 
-class Issue53Test extends DeltaTestCase
+class Issue55Test extends DeltaTestCase
 {
     public $json = <<<'JSON'
 {

--- a/tests/Issue55Test.php
+++ b/tests/Issue55Test.php
@@ -1,0 +1,245 @@
+<?php
+namespace nadar\quill\tests;
+
+use nadar\quill\InlineListener;
+use nadar\quill\Lexer;
+use nadar\quill\Line;
+use nadar\quill\listener\Image;
+
+class Issue53Test extends DeltaTestCase
+{
+    public $json = <<<'JSON'
+{
+   "ops":[
+      {
+         "insert":"Eye is a jewel of a town in North Suffolk with a wealth of interesting places to visit and friendly places to shop and eat. Dominated by its outstanding Victorian flint and brick "
+      },
+      {
+         "attributes":{
+            "bold":true
+         },
+         "insert":"Town Hall "
+      },
+      {
+         "insert":"commissioned in 1857 by E B Lamb, the town of Eye was until the 1970s the smallest borough in the country. The Town is built around "
+      },
+      {
+         "attributes":{
+            "bold":true
+         },
+         "insert":"Eye Castle"
+      },
+      {
+         "insert":" which possibly dates back to the eleventh century and is well worth a visit. You can take a leisurely walk around the town trail and visit some of the wonderful historic buildings. Recent spurts in population may see a step change in the town’s future development.\n"
+      },
+      {
+         "attributes":{
+            "color":"#666666"
+         },
+         "insert":"The magnificent fifteenth century Church of St Peter and St Paul is featured in the Churches and Chapels section of “"
+      },
+      {
+         "attributes":{
+            "color":"#222222",
+            "bold":true
+         },
+         "insert":"Days Out in Suffolk"
+      },
+      {
+         "attributes":{
+            "color":"#666666"
+         },
+         "insert":"” available from "
+      },
+      {
+         "attributes":{
+            "color":"#222222",
+            "bold":true
+         },
+         "insert":"Mid Suffolk Tourist Information Centre"
+      },
+      {
+         "attributes":{
+            "color":"#666666"
+         },
+         "insert":"."
+      },
+      {
+         "insert":"\n"
+      },
+      {
+         "attributes":{
+            "color":"#666666"
+         },
+         "insert":"Just beside the Church is the Guild Hall which again dates back to the 1400’s. The Guild’s activities could still be said to be alive represented by enthusiastic members of "
+      },
+      {
+         "attributes":{
+            "color":"#2d5c88",
+            "background":"#ffffff",
+            "link":"https://www.eyeartsguild.org.uk/"
+         },
+         "insert":"Eye Arts Guild"
+      },
+      {
+         "attributes":{
+            "color":"#666666"
+         },
+         "insert":". "
+      },
+      {
+         "attributes":{
+            "underline":true,
+            "italic":true,
+            "color":"#666666",
+            "bold":true
+         },
+         "insert":"Bararaq sei"
+      },
+      {
+         "attributes":{
+            "color":"#666666"
+         },
+         "insert":"."
+      },
+      {
+         "insert":"\n"
+      },
+      {
+         "attributes":{
+            "style":"width: 136px;",
+            "data-size":"200,200"
+         },
+         "insert":{
+            "image":"/about_images/UITBM"
+         }
+      },
+      {
+         "attributes":{
+            "align":"center"
+         },
+         "insert":"\n"
+      },
+      {
+         "attributes":{
+            "color":"#666666"
+         },
+         "insert":"The town is twinned with "
+      },
+      {
+         "attributes":{
+            "color":"#222222",
+            "bold":true
+         },
+         "insert":"Pouzauges"
+      },
+      {
+         "attributes":{
+            "color":"#666666"
+         },
+         "insert":" in France and this promotes links to continental tourism. There is no official Tourist Office in Eye, although McColls newsagent and convenience store keeps an array of leaflets which are available to tourists including "
+      },
+      {
+         "attributes":{
+            "color":"#222222",
+            "bold":true
+         },
+         "insert":"“Eye Suffolk, A Tourist Guide”"
+      },
+      {
+         "attributes":{
+            "color":"#666666"
+         },
+         "insert":", "
+      },
+      {
+         "attributes":{
+            "color":"#222222",
+            "bold":true
+         },
+         "insert":"“Heart of Suffolk Treasures”"
+      },
+      {
+         "attributes":{
+            "color":"#666666"
+         },
+         "insert":", "
+      },
+      {
+         "attributes":{
+            "color":"#222222",
+            "bold":true
+         },
+         "insert":"“Eye Cycle Route” "
+      },
+      {
+         "attributes":{
+            "color":"#666666"
+         },
+         "insert":"and the "
+      },
+      {
+         "attributes":{
+            "color":"#222222",
+            "bold":true
+         },
+         "insert":"“Eye Town Trail”"
+      },
+      {
+         "attributes":{
+            "color":"#666666"
+         },
+         "insert":"."
+      },
+      {
+         "insert":"\n"
+      },
+      {
+         "insert":{
+            "image":"/about_images/t3Cmt"
+         }
+      },
+      {
+         "attributes":{
+            "align":"right"
+         },
+         "insert":"\n"
+      }
+   ]
+}
+JSON;
+
+    public $html = <<<'EOT'
+<p>Eye is a jewel of a town in North Suffolk with a wealth of interesting places to visit and friendly places to shop and eat. Dominated by its outstanding Victorian flint and brick <strong>Town Hall </strong>commissioned in 1857 by E B Lamb, the town of Eye was until the 1970s the smallest borough in the country. The Town is built around <strong>Eye Castle</strong> which possibly dates back to the eleventh century and is well worth a visit. You can take a leisurely walk around the town trail and visit some of the wonderful historic buildings. Recent spurts in population may see a step change in the town’s future development.</p><p><span style="color:#666666">The magnificent fifteenth century Church of St Peter and St Paul is featured in the Churches and Chapels section of “</span><span style="color:#222222"><strong>Days Out in Suffolk</strong></span><span style="color:#666666">” available from </span><span style="color:#222222"><strong>Mid Suffolk Tourist Information Centre</strong></span><span style="color:#666666">.</span></p><p><span style="color:#666666">Just beside the Church is the Guild Hall which again dates back to the 1400’s. The Guild’s activities could still be said to be alive represented by enthusiastic members of </span><a href="https://www.eyeartsguild.org.uk/" target="_blank"><span style="color:#2d5c88">Eye Arts Guild</span></a><span style="color:#666666">. </span><u><span style="color:#666666"><em><strong>Bararaq sei</strong></em></span></u><span style="color:#666666">.</span></p><p style="text-align: center;"><img src="/about_images/UITBM" alt="" class="img-responsive img-fluid" /></p><p><span style="color:#666666">The town is twinned with </span><span style="color:#222222"><strong>Pouzauges</strong></span><span style="color:#666666"> in France and this promotes links to continental tourism. There is no official Tourist Office in Eye, although McColls newsagent and convenience store keeps an array of leaflets which are available to tourists including </span><span style="color:#222222"><strong>“Eye Suffolk, A Tourist Guide”</strong></span><span style="color:#666666">, </span><span style="color:#222222"><strong>“Heart of Suffolk Treasures”</strong></span><span style="color:#222222"><strong>“Eye Cycle Route” </strong></span><span style="color:#666666">and the </span><span style="color:#222222"><strong>“Eye Town Trail”</strong></span><span style="color:#666666">.</span></p><p style="text-align: right;"><img src="/about_images/t3Cmt" alt="" class="img-responsive img-fluid" /></p>
+EOT;
+
+  public function getLexer()
+  {
+        return new Lexer($this->json);
+  }
+
+  public function listeners(Lexer $lexer)
+  {
+      $lexer->overwriteListener(new Image, new ImageSizeListener);
+  }
+}
+
+class ImageSizeListener extends InlineListener {
+
+    public $wrapper = '<img src="{src}" alt="" class="img-responsive img-fluid" />';
+
+    public function process(Line $line)
+    {
+        $embedUrl = $line->insertJsonKey('image');
+        $imageStyles = $line->getAttribute('style');
+
+        if ($embedUrl) {
+            $this->updateInput($line, str_replace(['{src}'], [$line->getLexer()->escape($embedUrl)], $this->wrapper));
+        }
+
+        if ($imageStyles) {
+            $this->updateInput($line, str_replace(['{src}', '{styles}'], [$line->getLexer()->escape($embedUrl), $imageStyles], $this->wrapper));
+        }
+    }
+
+}


### PR DESCRIPTION
In order to override an internal, already registered listener we need a new method. Otherwise the experience of un-register and re-register all listeners is very painful and can make problems.

So i have added a new method `overwriteListener()`.

The problem is described here #55 

This closes #55 