### PR TITLE
Fix typo in "listeners"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This would render the following HTML:
 
 ## Extend the Parser
 
-In order to extend the Parser by adding your own listeneres (this can be the case if you are using quill plugins which generates custom delta code), you have to decide whether it's an:
+In order to extend the Parser by adding your own listeners (this can be the case if you are using quill plugins which generates custom delta code), you have to decide whether it's an:
 
 + inline element: Replaces content with new parsed content, this is mostly the case when working with quill extensions.
 + block element: Block elements which encloses the whole input with a tag, for example heading.
@@ -98,7 +98,7 @@ class Mention extends InlineListener
 }
 ```
 
-Now register the listenere:
+Now register the listener:
 
 ```php
 $lexer = new Lexer($json);

--- a/src/BlockListener.php
+++ b/src/BlockListener.php
@@ -5,7 +5,7 @@ namespace nadar\quill;
 /**
  * Block Listener
  *
- * Block listeneres writes from $line->input into the $line->output.
+ * Block listener writes from $line->input into the $line->output.
  *
  * @author Basil Suter <basil@nadar.io>
  * @since 1.0.0

--- a/src/InlineListener.php
+++ b/src/InlineListener.php
@@ -5,9 +5,9 @@ namespace nadar\quill;
 use Exception;
 
 /**
- * Inline Listenere.
+ * Inline listener.
  *
- * Inline listeneres changes the $line->input value!
+ * Inline listeners changes the $line->input value!
  *
  * @author Basil Suter <basil@nadar.io>
  * @since 1.0.0

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -157,6 +157,7 @@ class Lexer
 
     /**
      * Alias for loadBuiltinListeners() for compatibility
+     * @deprecated will be removed in 3.0
      */
     public function loadBuiltinListeneres()
     {
@@ -372,6 +373,7 @@ class Lexer
 
     /**
      * Alias for renderListeners() for compatibility
+     * @deprecated will be removed in 3.0
      */
     protected function renderListeneres($type)
     {

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -24,13 +24,13 @@ use nadar\quill\listener\CodeBlock;
  *
  * The lexer class represents the main thread in how delta input is processed and rendered.
  *
- * Basically Listeneres can watch every line of delta and interact with the line, which means
- * reading input and writting to output and mark this line as done, so other listeneres won't
+ * Basically listeners can watch every line of delta and interact with the line, which means
+ * reading input and writting to output and mark this line as done, so other listeners won't
  * take care of this line as well.
  *
  * ## Basic concept
  *
- * Listeneres are grouped in 2 types:
+ * Listeners are grouped in 2 types:
  *
  * + inline: For elements which are only inline applied, like writing bold or italic
  * + block: Used when the line represents a full html element like heading or lists
@@ -38,22 +38,22 @@ use nadar\quill\listener\CodeBlock;
  * Inside this group types there are 2 prioirities:
  *
  * + early bird: This is default value, the early bird catches the worm...
- * + garbage collector: This is mainly used for the text listenere which generates the paragraphs and can only be done at the very end of the process.
+ * + garbage collector: This is mainly used for the text listener which generates the paragraphs and can only be done at the very end of the process.
  *
- * Every listenere has two methods a process() and render():
+ * Every listener has two methods a process() and render():
  *
- * + process: is triggered by every line, so the listenere can choose whether he wants to pick this line, interact or not.
- * + render: after all lines are processed, every listenered triggers the render() method once, so the picked line from process can be "further" processed and rendered.
+ * + process: is triggered by every line, so the listener can choose whether he wants to pick this line, interact or not.
+ * + render: after all lines are processed, every listener triggers the render() method once, so the picked line from process can be "further" processed and rendered.
  *
  * ## Lifecycle
  *
  * 1. lines will be generated
  * 2. lines foreached and inline early bird listeners run process() method.
- * 3. lines foreached and inline garbage collector listeneres run process() method.
- * 4. lines foreached and block early bird listeneres run process() method.
- * 5. lines foreached and block garbage collector listenere run process() method.
- * 6. inline listeneres foreach and run render() method.
- * 7. block listeneres foreach and run render() method.
+ * 3. lines foreached and inline garbage collector listeners run process() method.
+ * 4. lines foreached and block early bird listeners run process() method.
+ * 5. lines foreached and block garbage collector listener run process() method.
+ * 6. inline listeners foreach and run render() method.
+ * 7. block listeners foreach and run render() method.
  *
  * @author Basil Suter <basil@nadar.io>
  * @since 1.0.0
@@ -104,7 +104,7 @@ class Lexer
     protected $json;
 
     /**
-     * @var array The listeneres grouped by type and priority.
+     * @var array The listeners grouped by type and priority.
      */
     protected $listeners = [
         Listener::TYPE_INLINE => [
@@ -121,7 +121,7 @@ class Lexer
      * Initializer
      *
      * @param string|array $json The delta ops json as string or as already parsed array.
-     * @param boolean $loadBuiltinListeneres Whether the built in listeneres should be loaded or not.
+     * @param boolean $loadBuiltinlisteners Whether the built in listeners should be loaded or not.
      */
     public function __construct($json, $loadBuiltinListeneres = true)
     {
@@ -133,7 +133,7 @@ class Lexer
     }
 
     /**
-     * Loads the library built in listeneres.
+     * Loads the library built in listeners.
      */
     public function loadBuiltinListeneres()
     {
@@ -156,7 +156,7 @@ class Lexer
     }
 
     /**
-     * Register a new listenere.
+     * Register a new listener.
      *
      * @param Listener $listener
      */
@@ -169,7 +169,7 @@ class Lexer
      * Overrite an existing listener with a new object
      *
      * An example could when you like to provide more options or access other elements which are not covered by the base class
-     * so you can extend from the built in listeneres and overrite them. This keeps also the hyrarchical level of the elements.
+     * so you can extend from the built in listeners and overrite them. This keeps also the hyrarchical level of the elements.
      * 
      * ```php
      * $lexer->overwriteListener(new Image, new MyOwnImage);
@@ -177,7 +177,7 @@ class Lexer
      * 
      * As the `new Image` listener is already registered, it will just replace the object with `new MyOwnImage`.
      * 
-     * @param Listener $listener The already registered listenere object
+     * @param Listener $listener The already registered listener object
      * @param Listener $new The new listener object
      * @see https://github.com/nadar/quill-delta-parser/issues/55
      * @since 2.8.0

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -123,11 +123,11 @@ class Lexer
      * @param string|array $json The delta ops json as string or as already parsed array.
      * @param boolean $loadBuiltinlisteners Whether the built in listeners should be loaded or not.
      */
-    public function __construct($json, $loadBuiltinListeneres = true)
+    public function __construct($json, $loadBuiltinListeners = true)
     {
         $this->json = $json;
 
-        if ($loadBuiltinListeneres) {
+        if ($loadBuiltinListeners) {
             $this->loadBuiltinListeneres();
         }
     }

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -128,14 +128,14 @@ class Lexer
         $this->json = $json;
 
         if ($loadBuiltinListeners) {
-            $this->loadBuiltinListeneres();
+            $this->loadBuiltinListeners();
         }
     }
 
     /**
      * Loads the library built in listeners.
      */
-    public function loadBuiltinListeneres()
+    public function loadBuiltinListeners()
     {
         $this->registerListener(new Image);
         $this->registerListener(new Bold);
@@ -153,6 +153,14 @@ class Lexer
         $this->registerListener(new Font);
         $this->registerListener(new Script);
         $this->registerListener(new Align);
+    }
+
+    /**
+     * Alias for loadBuiltinListeners() for compatibility
+     */
+    public function loadBuiltinListeneres()
+    {
+        return $this->loadBuiltinListeners();
     }
 
     /**
@@ -353,13 +361,21 @@ class Lexer
      * @param [type] $type
      * @return void
      */
-    protected function renderListeneres($type)
+    protected function renderListeners($type)
     {
         foreach ($this->listeners[$type] as $prios) {
             foreach ($prios as $listener) {
                 $listener->render($this);
             }
         }
+    }
+
+    /**
+     * Alias for renderListeners() for compatibility
+     */
+    protected function renderListeneres($type)
+    {
+        return $this->renderListeners($type);
     }
 
     /**
@@ -376,8 +392,8 @@ class Lexer
             $this->processListeners($line, Listener::TYPE_BLOCK);
         }
 
-        $this->renderListeneres(Listener::TYPE_INLINE);
-        $this->renderListeneres(Listener::TYPE_BLOCK);
+        $this->renderListeners(Listener::TYPE_INLINE);
+        $this->renderListeners(Listener::TYPE_BLOCK);
 
         $buff = null;
         foreach ($this->_lines as $line) {

--- a/src/Line.php
+++ b/src/Line.php
@@ -18,12 +18,12 @@ class Line
     const STATUS_CLEAN = 1;
 
     /**
-     * @var integer The status of the line if its picked by a listenere.
+     * @var integer The status of the line if its picked by a listener
      */
     const STATUS_PICKED = 2;
 
     /**
-     * @var integer The status of the line if some of the listeneres marked this line as done.
+     * @var integer The status of the line if some of the listener marked this line as done.
      */
     const STATUS_DONE = 3;
     

--- a/src/Listener.php
+++ b/src/Listener.php
@@ -5,7 +5,7 @@ namespace nadar\quill;
 /**
  * Listener Object.
  *
- * Every type of element is a listenere. Listeneres are "listening" to every line of delta code and can
+ * Every type of element is a listener. Listeners are "listening" to every line of delta code and can
  * pick and process this line.
  *
  * @author Basil Suter <basil@nadar.io>
@@ -30,7 +30,7 @@ abstract class Listener
 
     /**
      * @var integer Second priority listener within the given type. This is currently only used
-     * for TEXT listeneres - as they need to be the very last entry.
+     * for TEXT listeners - as they need to be the very last entry.
      */
     const PRIORITY_GARBAGE_COLLECTOR = 2;
 


### PR DESCRIPTION
Hi there

I just noticed a typo in the word "listener", and fixed it in the comments, variable and methods. For backwards compatibility, I've added alias methods for the "listenere" methods