### PR TITLE
Cleanup deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.x
+
++ [#63](https://github.com/nadar/quill-delta-parser/pull/63/) Removed deprecated methods `loadBuiltinListeneres()` and `renderListeneres()`.
+
 ## 3.0.0 (2. June 2022)
 
 > This release contains breaks which might affect your application. Checkout the [upgrade document](UPGRADE.md) for more details.

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -156,16 +156,6 @@ class Lexer
     }
 
     /**
-     * Alias for loadBuiltinListeners() for compatibility
-     * @deprecated will be removed in 3.0, use loadBuiltinListeners() instead.
-     */
-    public function loadBuiltinListeneres()
-    {
-        trigger_error("loadBuiltinListeneres() is deprecated, use loadBuiltinListeners() instead.", E_USER_NOTICE);
-        return $this->loadBuiltinListeners();
-    }
-
-    /**
      * Register a new listener.
      *
      * @param Listener $listener
@@ -370,16 +360,6 @@ class Lexer
                 $listener->render($this);
             }
         }
-    }
-
-    /**
-     * Alias for renderListeners() for compatibility
-     * @deprecated will be removed in 3.0, used renderListeners() instead.
-     */
-    protected function renderListeneres($type)
-    {
-        trigger_error("renderListeneres() is deprecated, use renderListeners() instead.", E_USER_NOTICE);
-        return $this->renderListeners($type);
     }
 
     /**


### PR DESCRIPTION
Cleanup alias methods added in https://github.com/nadar/quill-delta-parser/pull/58, now that we're in 3.x releases.