### PR TITLE
Cleanup deprecated `Line->input`

### DIFF
--- a/src/Debug.php
+++ b/src/Debug.php
@@ -100,7 +100,7 @@ class Debug
         foreach ($lines as $line) {
             $_lines[] = [
                 $line->getIndex(),
-                htmlentities($line->input, ENT_QUOTES),
+                $line->getInput(),
                 htmlentities($line->output, ENT_QUOTES),
                 htmlentities($line->renderPrepend(), ENT_QUOTES),
                 implode(", ", $line->getDebugInfo()),

--- a/src/InlineListener.php
+++ b/src/InlineListener.php
@@ -36,7 +36,7 @@ abstract class InlineListener extends Listener
     public function updateInput(Line $line, $value)
     {
         // we override the current element, and mark as done and mark as inline
-        $line->input = $value;
+        $line->setInput($value);
         $line->setDone();
         $line->setAsInline();
         $line->setAsEscaped();

--- a/src/InlineListener.php
+++ b/src/InlineListener.php
@@ -54,9 +54,9 @@ abstract class InlineListener extends Listener
             });
 
             if (!$next) {
-                throw new Exception("Unable to find a next element. Invalid DELTA on '{$pick->line->input}'. Maybe your delta code does not end with a newline?");
+                throw new Exception("Unable to find a next element. Invalid DELTA on '{$pick->line->getInput()}'. Maybe your delta code does not end with a newline?");
             }
-            $next->addPrepend($pick->line->input, $pick->line);
+            $next->addPrepend($pick->line->getInput(), $pick->line);
         }
     }
 }

--- a/src/Line.php
+++ b/src/Line.php
@@ -431,7 +431,6 @@ class Line
      *
      * @since 3.x.x
      * @param string $newInput
-     * @return string
      */
     public function setInput($newInput) {
         $this->input = $newInput;

--- a/src/Line.php
+++ b/src/Line.php
@@ -34,16 +34,15 @@ class Line
     public $prepend = [];
 
     /**
-     * @var string The input string which is assigned from the line parser. This is the actual content of the line itself!
-     * @deprecated Deprecated since 1.2.0 will be removed in 2.0 use getInput() instead.
-     */
-    public $input;
-
-    /**
      * @var string The output is the value which will actually rendered by the lexer. So lines which directly write to the output
      * buffer needs to fill in this variable.
      */
     public $output;
+
+    /**
+     * @var string The input string which is assigned from the line parser. This is the actual content of the line itself!
+     */
+    protected $input;
 
     /**
      * @var integer Holds the current status of the line.

--- a/src/Line.php
+++ b/src/Line.php
@@ -429,10 +429,11 @@ class Line
      * 
      * The new input is assumed to be escaped.
      *
-     * @since 3.x.x
+     * @since 3.1.0
      * @param string $newInput
      */
-    public function setInput($newInput) {
+    public function setInput($newInput)
+    {
         $this->input = $newInput;
     }
 

--- a/src/Line.php
+++ b/src/Line.php
@@ -41,6 +41,7 @@ class Line
 
     /**
      * @var string The input string which is assigned from the line parser. This is the actual content of the line itself!
+     * @since 3.1.0
      */
     protected $input;
 

--- a/src/Line.php
+++ b/src/Line.php
@@ -426,6 +426,19 @@ class Line
     }
 
     /**
+     * Adjust the line's input.
+     * 
+     * The new input is assumed to be escaped.
+     *
+     * @since 3.x.x
+     * @param string $newInput
+     * @return string
+     */
+    public function setInput($newInput) {
+        $this->input = $newInput;
+    }
+
+    /**
      * Setter method whether the current element is inline or not.
      */
     public function setAsInline()

--- a/src/listener/Color.php
+++ b/src/listener/Color.php
@@ -25,7 +25,7 @@ class Color extends InlineListener
     public function process(Line $line)
     {
         if (($color = $line->getAttribute('color'))) {
-            $this->updateInput($line, $this->ignore ? $line->input : '<span style="color:'.$line->getLexer()->escape($color).'">'.$line->getInput().'</span>');
+            $this->updateInput($line, $this->ignore ? $line->getInput() : '<span style="color:'.$line->getLexer()->escape($color).'">'.$line->getInput().'</span>');
         }
     }
 }

--- a/src/listener/Font.php
+++ b/src/listener/Font.php
@@ -39,9 +39,9 @@ class Font extends InlineListener
     public function applyTemplate($font, Line $line)
     {
         if ($this->ignore) {
-            return $line->input;
+            return $line->getInput();
         }
 
-        return '<span style="font-family: '.$line->getLexer()->escape($font).';">'. $line->input . '</span>';
+        return '<span style="font-family: '.$line->getLexer()->escape($font).';">'. $line->getInput() . '</span>';
     }
 }

--- a/src/listener/Script.php
+++ b/src/listener/Script.php
@@ -45,6 +45,6 @@ class Script extends InlineListener
           $script = 'sup';
         }
 
-        return '<'.$script.'>'. $line->input . '</'.$script.'>';
+        return '<'.$script.'>'. $line->getUnsafeInput() . '</'.$script.'>';
     }
 }

--- a/src/listener/Script.php
+++ b/src/listener/Script.php
@@ -45,6 +45,6 @@ class Script extends InlineListener
           $script = 'sup';
         }
 
-        return '<'.$script.'>'. $line->getUnsafeInput() . '</'.$script.'>';
+        return '<'.$script.'>'. $line->getInput() . '</'.$script.'>';
     }
 }

--- a/tests/FontAttributeTest.php
+++ b/tests/FontAttributeTest.php
@@ -6,9 +6,9 @@ use nadar\quill\listener\Font;
 
 class FontAttributeTest extends DeltaTestCase
 {
-    public $json = '{"ops":[{"insert":"Lorem "},{"attributes":{"font":"serif"},"insert":"Ipsum"},{"insert":" Dolor. "},{"attributes":{"font":"monospace"},"insert":"Sit"},{"insert":" Amet.\n"}]}';
+    public $json = '{"ops":[{"insert":"Lorem "},{"attributes":{"font":"serif"},"insert":"Ipsum"},{"insert":" Dolor. "},{"attributes":{"font":"monospace"},"insert":"Sit"},{"attributes":{"font":"arial"},"insert":"<script>"},{"insert":" Amet.\n"}]}';
 
-    public $html = '<p>Lorem Ipsum Dolor. Sit Amet.</p>';
+    public $html = '<p>Lorem Ipsum Dolor. Sit&lt;script&gt; Amet.</p>';
 
     public function listeners(\nadar\quill\Lexer $lexer)
     {

--- a/tests/LineTest.php
+++ b/tests/LineTest.php
@@ -50,7 +50,7 @@ class LineTest extends TestCase
 
         $line0 = $lexer->getLine(0);
 
-        $this->assertSame('line 1', $line0->input);
+        $this->assertSame('line 1', $line0->getInput());
 
         $this->assertTrue($line0->isFirst());
 
@@ -63,7 +63,7 @@ class LineTest extends TestCase
 
         $this->assertFalse($line1->isFirst());
 
-        $this->assertSame('line 2', $line1->input);
+        $this->assertSame('line 2', $line1->getInput());
         
         $prevLine = null;
         $line1->whilePrevious(function ($line) use (&$prevLine) {
@@ -71,7 +71,7 @@ class LineTest extends TestCase
             return false;
         });
 
-        $this->assertSame('line 1', $prevLine->input);
+        $this->assertSame('line 1', $prevLine->getInput());
 
         $value = false;
         $lineNoPrevious = $line0->whilePrevious(function ($line) use (&$value) {

--- a/tests/TextAttributesNoColorTest.php
+++ b/tests/TextAttributesNoColorTest.php
@@ -51,6 +51,12 @@ class TextAttributesNoColorTest extends DeltaTestCase
       "attributes": {
         "color": "#27333a"
       },
+      "insert": "<script>"
+    },
+    {
+      "attributes": {
+        "color": "#27333a"
+      },
       "insert": " Aarau"
     },
     {
@@ -59,7 +65,7 @@ class TextAttributesNoColorTest extends DeltaTestCase
 JSON;
 
     public $html = <<<'EOT'
-    <p><strong>Was: </strong>Mi</p><p><strong>Wann:</strong> März</p><p><strong>Wo:</strong> Aarau</p>
+    <p><strong>Was: </strong>Mi</p><p><strong>Wann:</strong> März</p><p><strong>Wo:</strong>&lt;script&gt; Aarau</p>
 EOT;
 
     public function listeners(\nadar\quill\Lexer $lexer)

--- a/tests/TextInjectionTest.php
+++ b/tests/TextInjectionTest.php
@@ -12,6 +12,7 @@ class TextInjectionTest extends DeltaTestCase
     {"insert": "<script>", "attributes": {"blockquote": true}},
     {"insert": "<script>", "attributes": {"bold": true}},
     {"insert": "<script>", "attributes": {"color": "<script>"}},
+    {"insert": "<script>", "attributes": {"font": "<script>"}},
     {"insert": "\n<script>"},
     {"insert": "\n", "attributes": {"header": 1}},
     {"insert": {"image": "<script>"}},
@@ -35,6 +36,7 @@ JSON;
 <p>
 <strong>&lt;script&gt;</strong>
 <span style="color:&lt;script&gt;">&lt;script&gt;</span>
+<span style="font-family: &lt;script&gt;;">&lt;script&gt;</span>
 </p>
 <h1>&lt;script&gt;</h1>
 <p><img src="&lt;script&gt;" alt="" class="img-responsive img-fluid" /></p>

--- a/tests/TextInjectionTest.php
+++ b/tests/TextInjectionTest.php
@@ -18,6 +18,8 @@ class TextInjectionTest extends DeltaTestCase
     {"insert": {"image": "<script>"}},
     {"insert": "\n"},
     {"insert": "<script>", "attributes": {"italic": true}},
+    {"insert": "<script>", "attributes": {"script": "super"}},
+    {"insert": "<script>", "attributes": {"script": "sub"}},
     {"insert": "<script>", "attributes": {"link": "<script>"}},
     {"insert": {"mention": {"id": "1", "value": "<script>", "denotationChar": "@"}}},
     {"insert": "\n<script>"},
@@ -42,6 +44,8 @@ JSON;
 <p><img src="&lt;script&gt;" alt="" class="img-responsive img-fluid" /></p>
 <p>
 <em>&lt;script&gt;</em>
+<sup>&lt;script&gt;</sup>
+<sub>&lt;script&gt;</sub>
 <a href="&lt;script&gt;" target="_blank">&lt;script&gt;</a>
 &lt;script&gt;
 </p>


### PR DESCRIPTION
This does a cleanup of the deprecation mark on `Line->input`.

There's still calls to that property for different reasons I think:

- some places should actually use `Line->getInput()`: https://github.com/nadar/quill-delta-parser/blob/master/src/listener/Color.php#L28, https://github.com/nadar/quill-delta-parser/blob/master/src/listener/Font.php#L42-L45
- some places actually need the unescaped data: https://github.com/nadar/quill-delta-parser/blob/master/src/listener/Script.php#L48
- some places need to write: https://github.com/nadar/quill-delta-parser/blob/master/src/InlineListener.php#L39

I haven't dived into the tests yet, however all tests are green. That also worries me a little though. While making and debugging I never got failed tests. For example switching `Script` to use `getInput` instead, no test breaks. So we probably need to add some tests to make sure this doesn't break anything.

- [x] investigate and make some tests