### PR TITLE
Make it easier to write json fixtures

### DIFF
--- a/tests/BlockquoteListenerTest.php
+++ b/tests/BlockquoteListenerTest.php
@@ -13,16 +13,14 @@ namespace nadar\quill\tests;
  */
 class BlockquoteListenerTest extends DeltaTestCase
 {
-    public $json = <<<'JSON'
-[
-    {
-        "insert" : "blockquote",
-      "attributes": {
-        "blockquote": true
-      }
-    }
-]
-JSON;
+    public $json = [
+        [
+            'insert' => 'blockquote',
+            'attributes' => [
+                'blockquote' => true,
+            ],
+        ],
+    ];
 
     public $html = '<blockquote>blockquote</blockquote>';
 }

--- a/tests/DeltaTestCase.php
+++ b/tests/DeltaTestCase.php
@@ -16,10 +16,6 @@ class DeltaTestCase extends TestCase
 
     public function getLexer()
     {
-        if (is_string($this->json) === false) {
-            $this->json = json_encode($this->json);
-        }
-        
         return new Lexer($this->json);
     }
 

--- a/tests/DeltaTestCase.php
+++ b/tests/DeltaTestCase.php
@@ -16,6 +16,10 @@ class DeltaTestCase extends TestCase
 
     public function getLexer()
     {
+        if (is_string($this->json) === false) {
+            $this->json = json_encode($this->json);
+        }
+        
         return new Lexer($this->json);
     }
 

--- a/tests/LinkWrapperOverrideTest.php
+++ b/tests/LinkWrapperOverrideTest.php
@@ -6,7 +6,17 @@ use nadar\quill\listener\Link;
 
 class LinkWrapperOverrideTest extends DeltaTestCase
 {
-    public $json = '[{"attributes":{"link":"https://luya.io"},"insert":"luya.io"},{"insert":" test\n\nFooter\n"}]';
+    public $json = [
+        [
+            'attributes' => [
+                'link' => 'https://luya.io',
+            ],
+            'insert' => 'luya.io',
+        ],
+        [
+            'insert' => ' test'.PHP_EOL.PHP_EOL.'Footer'.PHP_EOL,
+        ],
+    ];
 
     public $html = '<p><a href="https://luya.io">luya.io</a> test</p><p><br></p><p>Footer</p>';
 


### PR DESCRIPTION
This allows us to write json fixtures as php arrays instead of json strings.

IMHO this is more readable. And it also allows for better syntax error finding. And it prevents to get syntax errors when forgetting to remove a trailing comma. :)

I converted 2 test classes as an example.

Do you like @nadar? If so, I can convert the other classes as well if we want that.