### PR TITLE
Fix issue #87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.4.2 (5. April 2024)
+
++ [#87](https://github.com/nadar/quill-delta-parser/issues/87) Fixed a bug where a line break preceding a list containing inline attributes results in improper HTML formatting for next paragraphs.
+
 ## 3.4.1 (13. March 2024)
 
 + [#84](https://github.com/nadar/quill-delta-parser/issues/84) Allow align `left` as possible value.

--- a/src/listener/Text.php
+++ b/src/listener/Text.php
@@ -86,7 +86,7 @@ class Text extends BlockListener
 
                 // If this element is empty we should maybe directly close and reopen this paragraph as it could be an empty line with
                 // a next elmenet
-                } elseif ($pick->line->isEmpty() && $next) {
+                } elseif ($pick->line->isEmpty() && $next && !$next->isDone()) {
                     $isOpen = $this->output($output, self::CLOSEP.self::OPENP, true);
 
                 // if its open, and it had an end newline, lets close

--- a/tests/Issue87Test.php
+++ b/tests/Issue87Test.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace nadar\quill\tests;
+
+class Issue87Test extends DeltaTestCase
+{
+    public $json = <<<'JSON'
+{
+    "ops": 
+    [
+      {
+        "insert": "This is begin text:\n\n"
+      },
+      {
+        "attributes": {
+          "bold": true
+        },
+        "insert": "Bold text"
+      },
+      {
+        "insert": " and regular text"
+      },
+      {
+        "attributes": {
+          "list": "bullet"
+        },
+        "insert": "\n"
+      },
+      {
+        "insert": "Another bullet"
+      },
+      {
+        "attributes": {
+          "list": "bullet"
+        },
+        "insert": "\n"
+      },
+      {
+        "insert": "Another text after list"
+      }
+    ]
+}
+JSON;
+
+    public $html = <<<'EOT'
+    <p>This is begin text:</p><p><br></p><ul><li><strong>Bold text</strong> and regular text</li><li>Another bullet</li></ul><p>Another text after list</p>
+EOT;
+}


### PR DESCRIPTION
This pull request addresses the issue described in #87, where a line break preceding a list containing inline attributes results in improper HTML formatting.

this closes #87 